### PR TITLE
regenerate crds & add printcolumn

### DIFF
--- a/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
+++ b/addon/v1alpha1/0000_00_addon.open-cluster-management.io_clustermanagementaddons.crd.yaml
@@ -4,6 +4,13 @@ metadata:
   creationTimestamp: null
   name: clustermanagementaddons.addon.open-cluster-management.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.displayName
+    name: DISPLAY NAME
+    type: string
+  - JSONPath: .spec.addOnConfigCRD
+    name: CRD NAME
+    type: string
   group: addon.open-cluster-management.io
   names:
     kind: ClusterManagementAddOn
@@ -17,13 +24,11 @@ spec:
   validation:
     openAPIV3Schema:
       description: ClusterManagementAddOn represents the registration of an add-on
-        to the cluster manager. This resource allows the user to discover which add-on
-        is available for the cluster manager and also provides metadata information
-        about the add-on. The resource also provides a linkage to ManagedClusterAddOn,
-        the name of the ClusterManagementAddOn resource will be use for the namespace
-        scoped ManagedClusterAddOn resource ClusterManagementAddOn is a cluster scoped
-        resource.
-      type: object
+        to the cluster management. This resource allows the user to discover which
+        add-on is available for the cluster management and also provides metadata
+        information about the add-on. The resource also provides a linkage to ManagedClusterAddOn,
+        the name of the ClusterManagementAddOn resource will be used for the namespace-scoped
+        ManagedClusterAddOn resource ClusterManagementAddOn is a cluster-scoped resource.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -39,14 +44,13 @@ spec:
           type: object
         spec:
           description: Spec represents a desired configuration for the agent on the
-            cluster manager add-on
-          type: object
+            cluster management add-on.
           properties:
             addOnConfigCRD:
               description: 'AddOnConfigCRD is a reference to the name of the CRD that
-                driving the configuration of the add-on Note: there may be a case
-                where a single add-on config CRD controls multiple related add-ons,
-                in this case multiple ClusterManagementAddOn resource should be created.'
+                configures the add-on Note: There may be a case where a single add-on
+                config CRD controls multiple related add-ons, in this case multiple
+                ClusterManagementAddOn resource should be created.'
               type: string
             description:
               description: Description represents the detailed description of the
@@ -55,9 +59,12 @@ spec:
             displayName:
               description: DisplayName represents the name that will be displayed.
               type: string
-        status:
-          description: Status represents the current status of cluster manager add-on
           type: object
+        status:
+          description: Status represents the current status of cluster management
+            add-on.
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/addon/v1alpha1/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -4,6 +4,13 @@ metadata:
   creationTimestamp: null
   name: managedclusteraddons.addon.open-cluster-management.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Progressing")].status
+    name: Progressing
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Available")].status
+    name: Available
+    type: string
   group: addon.open-cluster-management.io
   names:
     kind: ManagedClusterAddOn
@@ -12,15 +19,14 @@ spec:
     singular: managedclusteraddon
   preserveUnknownFields: false
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: ManagedClusterAddOn is the Custom Resource object which holds the
         current state of an add-on. This object is used by add-on operators to convey
         their state. The resource should be created in the ManagedCluster's cluster
         namespace.
-      type: object
-      required:
-      - spec
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -40,17 +46,11 @@ spec:
         status:
           description: status holds the information about the state of an operator.  It
             is consistent with status information across the Kubernetes ecosystem.
-          type: object
           properties:
             addOnResource:
               description: addOnResource is a reference to the detailed resource driving
                 the add-on this resource must be located in the same namespace as
                 the ManagedClusterAddOn
-              type: object
-              required:
-              - group
-              - name
-              - resource
               properties:
                 group:
                   description: group of the referent.
@@ -61,24 +61,23 @@ spec:
                 resource:
                   description: resource of the referent.
                   type: string
+              required:
+              - group
+              - name
+              - resource
+              type: object
             conditions:
               description: conditions describe the state of the operator's managed
                 and monitored components.
-              type: array
               items:
                 description: AddOnStatusCondition represents the state of the add-on's
                   managed and monitored components.
-                type: object
-                required:
-                - lastTransitionTime
-                - status
-                - type
                 properties:
                   lastTransitionTime:
                     description: lastTransitionTime is the time of the last update
                       to the current status property.
-                    type: string
                     format: date-time
+                    type: string
                   message:
                     description: message provides additional information about the
                       current condition. This is only to be consumed by humans.
@@ -93,6 +92,16 @@ spec:
                   type:
                     description: type specifies the aspect reported by this condition.
                     type: string
+                required:
+                - lastTransitionTime
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      required:
+      - spec
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1

--- a/addon/v1alpha1/types_clustermanagementaddon.go
+++ b/addon/v1alpha1/types_clustermanagementaddon.go
@@ -9,6 +9,8 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope="Cluster"
+// +kubebuilder:printcolumn:name="DISPLAY NAME",type=string,JSONPath=`.spec.displayName`
+// +kubebuilder:printcolumn:name="CRD NAME",type=string,JSONPath=`.spec.addOnConfigCRD`
 
 // ClusterManagementAddOn represents the registration of an add-on to the cluster management.
 // This resource allows the user to discover which add-on is available for the cluster management and

--- a/addon/v1alpha1/types_managedclusteraddon.go
+++ b/addon/v1alpha1/types_managedclusteraddon.go
@@ -6,6 +6,9 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`
+// +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.conditions[?(@.type=="Available")].status`
 
 // ManagedClusterAddOn is the Custom Resource object which holds the current state
 // of an add-on. This object is used by add-on operators to convey their state.


### PR DESCRIPTION
Updates:
- Regenerated crds to pickup latest comment changes
- Added print column & subresource

Used my own controller-gen (latest) to generate printcolumn, the given version in this repo seems doesn't work?
but it still passed verification 😂 

print column example:
```
% oc get managedclusteraddons
NAME                                                PROGRESSING   AVAILABLE
open-cluster-management-addon-application-manager   True          False
% oc get clustermanagementaddons
NAME                                                DISPLAY NAME          CRD NAME
open-cluster-management-addon-application-manager   application-manager   klusterletaddonconfigs.agent.open-cluster-management.io
```